### PR TITLE
Improved flake.nix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 result
 result-*
-/flake.lock

--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ let
 in napalm.buildPackage ./. { packageLock = <path/to/package-lock>; }
 ```
 
+### Napalm with Nix flakes
+
+If you want to use Napalm in your flake project, you can do that by adding it to your overlay. There is also a template, that can help you use napalm in your project. You can use it by running `nix flake init -t "github:nix-community/napalm"`.
+
 ## Napalm - a lightweight npm registry
 
 Under the hood napalm uses its own package regitry. The registry is available

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,26 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1628577115,
+        "narHash": "sha256-aasewQt89VaGZBDJscpnvl6HvlqCckzJMosd4McH6kI=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "64324abe1594631fea09dee0ffc46f11221b4300",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "ref": "master",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -30,6 +30,9 @@
       devShell = forAllSystems
         (system: nixpkgsFor.${system}.napalm.napalm-registry-devshell);
 
-      
+      defaultTemplate = {
+        path = ./template;
+        description = "Template for using Napalm with flakes";
+      };
     };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -1,21 +1,35 @@
 {
   description = "Build NPM packages in Nix and lightweight NPM registry";
+  inputs.nixpkgs.url = "nixpkgs/master";
 
-  outputs = { self, nixpkgs }: let
-    systems = [ "i686-linux" "x86_64-linux" "aarch64-linux" "x86_64-darwin" ];
-  in {
-    overlay = final: prev: {
-      napalm = {
-        inherit (import ./. { pkgs = final; })
-          buildPackage snapshotFromPackageLockJson;
-      };
+  outputs = { self, nixpkgs }:
+    let
+      # List of systems that are supported
+      supportedSystems =
+        [ "x86_64-linux" "aarch64-linux" "i686-linux" "x86_64-darwin" ];
+
+      # Helper function to generate an attrset '{ x86_64-linux = f "x86_64-linux"; ... }'.
+      forAllSystems = f:
+        nixpkgs.lib.genAttrs supportedSystems (system: f system);
+
+      # Nixpkgs instantiated for supported system types.
+      nixpkgsFor = forAllSystems (system:
+        import nixpkgs {
+          inherit system;
+          overlays = [ self.overlay ];
+        });
+    in {
+      overlay = final: prev: { napalm = import ./. { pkgs = final; }; };
+
+      packages = forAllSystems (system: {
+        inherit (nixpkgsFor.${system}.napalm)
+          hello-world hello-world-deps netlify-cli deckdeckgo-starter
+          bitwarden-cli napalm-registry;
+      });
+
+      devShell = forAllSystems
+        (system: nixpkgsFor.${system}.napalm.napalm-registry-devshell);
+
+      
     };
-
-    checks = nixpkgs.lib.genAttrs systems (system: let
-      pkgs = nixpkgs.legacyPackages.${system};
-    in removeAttrs (import ./. { inherit pkgs; }) [
-      "buildPackage" "napalm-registry" "napalm-registry-devshell"
-      "snapshotFromPackageLockJson"
-    ]);
-  };
 }

--- a/template/flake.nix
+++ b/template/flake.nix
@@ -1,0 +1,55 @@
+{
+  description = "An example of Napalm with flakes";
+
+  # Nixpkgs / NixOS version to use.
+  inputs.nixpkgs.url = "nixpkgs/master";
+
+  # Import napalm
+  inputs.napalm.url = "github:nix-community/napalm";
+
+  outputs = { self, nixpkgs, napalm }:
+    let
+      # Generate a user-friendly version numer.
+      version = builtins.substring 0 8 self.lastModifiedDate;
+
+      # System types to support.
+      supportedSystems = [ "x86_64-linux" ];
+
+      # Helper function to generate an attrset '{ x86_64-linux = f "x86_64-linux"; ... }'.
+      forAllSystems = f:
+        nixpkgs.lib.genAttrs supportedSystems (system: f system);
+
+      # Nixpkgs instantiated for supported system types.
+      nixpkgsFor = forAllSystems (system:
+        import nixpkgs {
+          inherit system;
+          # Use napalm as your overlay
+          overlays = [ self.overlay napalm.overlay ];
+        });
+
+    in {
+
+      # A Nixpkgs overlay.
+      overlay = final: prev:
+        let
+          # In case you do not want to use overlay, you can use:
+          buildNapalmPackage = (napalm.overlay final prev).napalm.buildPackage;
+          # It would work the same way as final.napalm.buildPackage in this case
+        in {
+          # Example packages
+          hello-world = final.napalm.buildPackage ./hello-world { };
+          hello-world-deps = final.napalm.buildPackage ./hello-world-deps { };
+        };
+
+      # Provide your packages for selected system types.
+      packages = forAllSystems (system: {
+        inherit (nixpkgsFor.${system}) hello-world hello-world-deps;
+      });
+
+      # The default package for 'nix build'. This makes sense if the
+      # flake provides only one package or there is a clear "main"
+      # package.
+      defaultPackage =
+        forAllSystems (system: self.packages.${system}.hello-world);
+    };
+}

--- a/template/hello-world-deps/cli.js
+++ b/template/hello-world-deps/cli.js
@@ -1,0 +1,4 @@
+#!/usr/bin/env node
+
+const _ = require("underscore");
+console.log(_.range(5));

--- a/template/hello-world-deps/package-lock.json
+++ b/template/hello-world-deps/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "hello-world-deps",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "underscore": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.1.tgz",
+      "integrity": "sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg=="
+    }
+  }
+}

--- a/template/hello-world-deps/package.json
+++ b/template/hello-world-deps/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "hello-world-deps",
+  "version": "1.0.0",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC",
+  "bin": {
+    "say-hello": "./cli.js"
+  },
+  "dependencies": {
+    "underscore": "^1.9.1"
+  },
+  "devDependencies": {},
+  "description": ""
+}

--- a/template/hello-world/cli.js
+++ b/template/hello-world/cli.js
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+
+console.log("Hello, World!");

--- a/template/hello-world/package-lock.json
+++ b/template/hello-world/package-lock.json
@@ -1,0 +1,5 @@
+{
+    "name": "hello-world",
+    "version": "1.0.0",
+    "lockfileVersion": 1
+}

--- a/template/hello-world/package.json
+++ b/template/hello-world/package.json
@@ -1,0 +1,14 @@
+{
+    "name": "hello-world",
+    "version": "1.0.0",
+    "description": "",
+    "main": "index.js",
+    "scripts": {
+        "test": "echo \"Error: no test specified\" && exit 1"
+    },
+    "author": "",
+    "license": "ISC",
+    "bin": {
+        "say-hello": "./cli.js"
+    }
+}


### PR DESCRIPTION
This PR improves flake.nix ~and fixes #36~ .

~In order to make repository fully compatible with flake.nix it was required to stop using `callCabal2nix` and to use `cabal2nix` to manually create `napalm-registry` via `updateDefault.sh` script.~

Flake additions:
- Packages that can be built via `nix build`
- Access to development shell via `nix develop`
- Overlay that can be used in other flakes
- ~Checks that can be run to ensure that everything builds correctly~
- Specified `nixpkgs` version
- Simple template for easier Napalm usage with flakes