### PR TITLE
Fixed lock-patcher not working for older node.js versions

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -398,7 +398,7 @@ let
               ${if
                 # If version of the node.js is below 14.13.0 there is no ESM
                 # module support by node.js
-                builtins.compareVersions nodejs.version "14.13.0" > 0
+                lib.versionAtLeast nodejs.version "14.13.0"
                 then nodejs else pkgs.nodejs
                }/bin/node ${./scripts}/lock-patcher.mjs ${snapshot}
             ''}


### PR DESCRIPTION
While using the latest version of Napalm, I have discovered that when node.js version is below `14.13.0`, then it will fail running `lock-patcher.mjs` due to module or `fsPromise` support. This PR makes it so that when node.js version is below `14.13.0` it will use the latest node.js from the nixpkgs, otherwise it will use the one specified by the user.