### PR TITLE
Remove reliance on import from derivation

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -500,7 +500,7 @@ let
 
   haskellPackages = pkgs.haskellPackages.override {
     overrides = _: haskellPackages: {
-      napalm-registry = haskellPackages.callCabal2nix "napalm-registry" napalm-registry-source { };
+      napalm-registry = haskellPackages.callPackage napalm-registry-source { };
     };
   };
 

--- a/napalm-registry/README.md
+++ b/napalm-registry/README.md
@@ -1,0 +1,5 @@
+# napalm-registry
+
+After changing `napalm-registry.cabal`, make sure to execute
+`cabal2nix . > default.nix`, so the Nix package definition
+is regenerated.

--- a/napalm-registry/default.nix
+++ b/napalm-registry/default.nix
@@ -1,0 +1,20 @@
+{ mkDerivation, aeson, base, base16-bytestring, bytestring
+, cryptohash, hashable, hpack, lib, optparse-applicative, servant
+, servant-server, tar, text, time, unordered-containers, uri-encode
+, warp, zlib
+}:
+mkDerivation {
+  pname = "napalm-registry";
+  version = "0.0.0";
+  src = ./.;
+  isLibrary = false;
+  isExecutable = true;
+  libraryToolDepends = [ hpack ];
+  executableHaskellDepends = [
+    aeson base base16-bytestring bytestring cryptohash hashable
+    optparse-applicative servant servant-server tar text time
+    unordered-containers uri-encode warp zlib
+  ];
+  prePatch = "hpack";
+  license = lib.licenses.mit;
+}


### PR DESCRIPTION
`callCabal2nix` runs `cabal2nix` internally to obtain a package
description for a given Cabal file. Since this uses IFD, the single
threaded evaluator has to stop until that build has finished. This is
usually a slight annoyance, but can in the worst case require to build
GHC if binary cache is lacking.

We can avoid this by simply manually generating the file and checking it
in.