### PR TITLE
Clean up flake.nix

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "flake-utils": {
       "locked": {
-        "lastModified": 1631561581,
-        "narHash": "sha256-3VQMV5zvxaVLvqqUrNz3iJelLw30mIVSfZmAaauM3dA=",
+        "lastModified": 1659877975,
+        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "7e5bf3925f6fbdfaf50a2a7ca0be2879c4261d19",
+        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
         "type": "github"
       },
       "original": {
@@ -17,11 +17,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1629618782,
-        "narHash": "sha256-2K8SSXu3alo/URI3MClGdDSns6Gb4ZaW4LET53UWyKk=",
+        "lastModified": 1662911228,
+        "narHash": "sha256-oJOrB2lEeBLaO8g1DKG5PK9a1zyOWypkscrEfxxEj8A=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "870959c7fb3a42af1863bed9e1756086a74eb649",
+        "rev": "c97e777ff06fcb8d37dcdf5e21e9eff1f34f0e90",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -1,45 +1,56 @@
 {
   description = "Build NPM packages in Nix and lightweight NPM registry";
+
   inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
   inputs.flake-utils.url = "github:numtide/flake-utils";
 
   outputs = { self, nixpkgs, flake-utils }:
-    let
-      internal_overlay = final: prev: {
+    flake-utils.lib.eachDefaultSystem
+      (system:
+        let
+          napalm = import ./. {
+            pkgs = nixpkgs.legacyPackages.${system};
+          };
+        in
+        {
+          packages = (nixpkgs.lib.filterAttrs (_: nixpkgs.lib.isDerivation) napalm) // {
+            default = napalm.napalm-registry;
+          };
+
+          legacyPackages = nixpkgs.lib.filterAttrs (_: builtins.isFunction) napalm;
+
+          devShells.default = napalm.napalm-registry-devshell;
+
+          checks.template-simple =
+            let
+              flake = import (self.templates.simple.path + /flake.nix);
+              flakeSelf = flake // flake.outputs;
+            in
+            (flake.outputs { inherit nixpkgs; self = flakeSelf; napalm = self.outputs; }).packages.${system}.hello-world;
+        }) // {
+
+      overlays.default = final: _: nixpkgs.lib.filterAttrs (_: nixpkgs) {
         napalm = import ./. {
           pkgs = final;
         };
       };
-    in
-    flake-utils.lib.eachDefaultSystem
-      (
-        system:
-        let
-          pkgs = import nixpkgs { inherit system; overlays = [ internal_overlay ]; };
-        in
-        {
-          packages = {
-            inherit (pkgs.napalm)
-              hello-world hello-world-deps netlify-cli deckdeckgo-starter
-              bitwarden-cli napalm-registry
-              ;
-          };
 
-          devShell = pkgs.napalm.napalm-registry-devshell;
-        }
-      ) // {
-      overlay = final: prev: builtins.removeAttrs (internal_overlay final prev) [
-        "hello-world"
-        "hello-world-deps"
-        "netlify-cli"
-        "deckdeckgo-starter"
-        "bitwarden-cli"
-        "napalm-registry"
-      ];
-
-      defaultTemplate = {
+      templates.simple = {
         path = ./template;
         description = "Template for using Napalm with flakes";
+        welcomeText = ''
+          # Simple Napalm Node.js Template
+
+          ## Intended Usage
+
+          This flake is to get you started with a working example of Napalm.
+
+          ## More info
+
+          - [Node.js Website](https://nodejs.org/en/)
+          - [Napalm](https://github.com/nix-community/napalm)
+        '';
       };
+      templates.default = self.templates.simple;
     };
 }


### PR DESCRIPTION
Clean up the flake.nix file with some functions, change the outputs to use the new "default" output types, clean up corresponding flake template, and add a flake-template check.

Updated the flake.lock file as well to update ghc and have all checks pass.

Signed-off-by: David Houston <houstdav000@gmail.com>