### PR TITLE
flake: Clean up overlay

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -4,45 +4,40 @@
   inputs.flake-utils.url = "github:numtide/flake-utils";
 
   outputs = { self, nixpkgs, flake-utils }:
-    let
-      internal_overlay = final: prev: {
-        napalm = import ./. {
-          pkgs = final;
-        };
-      };
-    in
     flake-utils.lib.eachDefaultSystem
-      (
-        system:
+      (system:
         let
-          pkgs = import nixpkgs { inherit system; overlays = [ internal_overlay ]; };
+          napalm = import ./. {
+            pkgs = nixpkgs.legacyPackages."${system}";
+          };
         in
         {
           legacyPackages = {
-            inherit (pkgs.napalm)
+            inherit (napalm)
               buildPackage
               snapshotFromPackageLockJson
               ;
           };
 
           packages = {
-            inherit (pkgs.napalm)
-              hello-world hello-world-deps netlify-cli deckdeckgo-starter
-              bitwarden-cli napalm-registry
+            inherit (napalm)
+              hello-world
+              hello-world-deps
+              netlify-cli
+              deckdeckgo-starter
+              bitwarden-cli
+              napalm-registry
               ;
           };
 
-          devShell = pkgs.napalm.napalm-registry-devshell;
+          devShell = napalm.napalm-registry-devshell;
         }
       ) // {
-      overlay = final: prev: builtins.removeAttrs (internal_overlay final prev) [
-        "hello-world"
-        "hello-world-deps"
-        "netlify-cli"
-        "deckdeckgo-starter"
-        "bitwarden-cli"
-        "napalm-registry"
-      ];
+      overlay = final: prev: {
+        napalm = import ./. {
+          pkgs = final;
+        };
+      };
 
       defaultTemplate = {
         path = ./template;


### PR DESCRIPTION
An internal overlay doesn't really need to be created and makes things a lot more complicated conceptually. This commit should just simplify things without changing the exposed outputs.