### PR TITLE
flake: Add legacyPackages Outputs

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -18,6 +18,13 @@
           pkgs = import nixpkgs { inherit system; overlays = [ internal_overlay ]; };
         in
         {
+          legacyPackages = {
+            inherit (pkgs.napalm)
+              buildPackage
+              snapshotFromPackageLockJson
+              ;
+          };
+
           packages = {
             inherit (pkgs.napalm)
               hello-world hello-world-deps netlify-cli deckdeckgo-starter


### PR DESCRIPTION
Add a legacyPackages output for exposing the build functions, since a `lib` wouldn't work correctly with system, and packages must be derivations.