### PR TITLE
template: Clean up outputs

### DIFF
--- a/template/flake.nix
+++ b/template/flake.nix
@@ -7,46 +7,36 @@
   # Import napalm
   inputs.napalm.url = "github:nix-community/napalm";
 
+  # Configuring "follows" lets you configure the source for the build environment.
+  inputs.napalm.inputs.nixpkgs.follows = "nixpkgs";
+
   outputs = { self, nixpkgs, napalm }:
     let
-      # Generate a user-friendly version number.
-      version = builtins.substring 0 8 self.lastModifiedDate;
-
       # System types to support.
       supportedSystems = [ "x86_64-linux" "aarch64-linux" "i686-linux" "x86_64-darwin" "aarch64-darwin" ];
 
       # Helper function to generate an attrset '{ x86_64-linux = f "x86_64-linux"; ... }'.
-      forAllSystems = f:
-        nixpkgs.lib.genAttrs supportedSystems (system: f system);
-
-      # Nixpkgs instantiated for supported system types.
-      nixpkgsFor = forAllSystems (system:
-        import nixpkgs {
-          inherit system;
-          # Add napalm to you overlay's list
-          overlays = [
-            self.overlay
-            napalm.overlay
-          ];
-        });
-
+      forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
     in
     {
       # A Nixpkgs overlay.
-      overlay = final: prev: {
-        # Example package
-        hello-world = final.napalm.buildPackage ./hello-world { };
-      };
+      overlay = final: prev:
+        let
+          napalmPkg = napalm.legacyPackages."${final.stdenv.hostPlatform.system}";
+        in
+        {
+          hello-world = napalmPkg.buildPackage ./hello-world { };
+        };
 
       # Provide your packages for selected system types.
       packages = forAllSystems (system: {
-        inherit (nixpkgsFor.${system}) hello-world;
+        hello-world = napalm.legacyPackages."${system}".buildPackage ./hello-world { };
       });
 
       # The default package for 'nix build'. This makes sense if the
       # flake provides only one package or there is a clear "main"
       # package.
       defaultPackage =
-        forAllSystems (system: self.packages.${system}.hello-world);
+        forAllSystems (system: self.packages."${system}".hello-world);
     };
 }

--- a/template/flake.nix
+++ b/template/flake.nix
@@ -19,13 +19,16 @@
       forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
     in
     {
-      # A Nixpkgs overlay.
+      # Advanced: A Nixpkgs overlay.
       overlay = final: prev:
         let
-          napalmPkg = napalm.legacyPackages."${final.stdenv.hostPlatform.system}";
+          # To keep the overlay pure, conditionally use the napalm overlay and
+          #   default to using the napalm package from the overlaid nixpkgs if
+          #   it exists.
+          pkgsWithNapalm = if prev ? napalm.buildPackage then prev else napalm.overlay final prev;
         in
         {
-          hello-world = napalmPkg.buildPackage ./hello-world { };
+          hello-world = pkgsWithNapalm.napalm.buildPackage ./hello-world { };
         };
 
       # Provide your packages for selected system types.
@@ -34,8 +37,8 @@
       });
 
       # The default package for 'nix build'. This makes sense if the
-      # flake provides only one package or there is a clear "main"
-      # package.
+      #   flake provides only one package or there is a clear "main"
+      #   package.
       defaultPackage =
         forAllSystems (system: self.packages."${system}".hello-world);
     };


### PR DESCRIPTION
Clean up the template functions and outputs using the legacyPackages napalm output and an eta reduction.

It might also be easier to clean things up if we used flake-utils, but not sure if we want to force that on downstream users.