### PR TITLE
napalm-registry: derive Eq PackageTag for hashable >= 1.4

### DIFF
--- a/napalm-registry/Main.hs
+++ b/napalm-registry/Main.hs
@@ -243,7 +243,7 @@ type API =
   Capture "package_name" PackageName :> Get '[JSON] PackageMetadata
 
 newtype PackageTag = PackageTag { _unPackageTag :: T.Text }
-  deriving newtype ( Aeson.ToJSONKey, IsString, Hashable )
+  deriving newtype ( Aeson.ToJSONKey, Eq, IsString, Hashable )
 newtype PackageVersion = PackageVersion { unPackageVersion :: T.Text }
   deriving newtype ( Eq, Ord, Hashable, FromHttpApiData, Aeson.ToJSONKey, Aeson.FromJSONKey, Aeson.ToJSON )
 data ScopedPackageName = ScopedPackageName { _spnScope :: Maybe ScopeName, spnName :: PackageName }


### PR DESCRIPTION
hashable-1.4.0.0 made Eq a superclass of Hashable: https://hackage.haskell.org/package/hashable-1.4.0.0/changelog

hashable >= 1.4 is included in Stackage LTS-20 which nixpkgs uses since a few days.