### PR TITLE
napalm-registry: Bind to IPv6 address

### DIFF
--- a/napalm-registry/Main.hs
+++ b/napalm-registry/Main.hs
@@ -69,7 +69,7 @@ main = do
         (port,sock) <- Warp.openFreePort
         putStrLn ("Warp picked port " <> show port <> ", reporting to " <> reportTo)
         writeFile reportTo (show port)
-        let settings = Warp.defaultSettings & Warp.setPort port
+        let settings = Warp.defaultSettings & Warp.setHost "*" & Warp.setPort port
         Warp.runSettingsSocket settings sock (Servant.serve api (server config port snapshot))
 
 parseConfig :: Opts.Parser Config


### PR DESCRIPTION
Warp defaults to `HostIPv4`, binding only to IPv4 when possible. That breaks on Darwin, which appears to resolve `localhost` to `::1`.

Let’s bind to both IPv6 and IPv4 addresses.

Fixes: https://github.com/nix-community/napalm/issues/56