### PR TITLE
napalm-registry: enable threaded mode

### DIFF
--- a/napalm-registry/package.yaml
+++ b/napalm-registry/package.yaml
@@ -22,6 +22,7 @@ dependencies:
 ghc-options:
     - -Wall
     - -Werror
+    - -threaded
 
 executable:
     main: Main.hs


### PR DESCRIPTION
Otherwise the registry might crash with the following error:

    napalm-registry: file descriptor 7641728 out of range for select (0--1024).ules/fsevents/node_modules/gau
    Recompile with -threaded to work around this.
